### PR TITLE
Add test rig for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - '2.7'
+virtualenv:
+  system_site_packages: true
+before_install:
+  - sudo add-apt-repository ppa:pylab/stable -y
+  - sudo apt-get update -q
+  - sudo apt-get install -qq libopenblas-dev liblapack-dev gfortran # install these first
+  - sudo apt-get install -qq python-numpy python-scipy
+script: make test


### PR DESCRIPTION
To set up Travis, you can go to https://travis-ci.org/ and link your github account. Then flick the switch for this repository.

If you set up Travis before you merge, the first Travis build should run then. Otherwise you'll have to push another commit afterward.

Tests passing on bodylabs fork; probably should pass here too.
