### PR TITLE
Prevent naming overrides conflicts in setup_terms for legacy code

### DIFF
--- a/ch.py
+++ b/ch.py
@@ -119,7 +119,7 @@ class Ch(object):
 
     @classmethod
     def setup_terms(cls):
-        if cls.__name__ in cls._setup_terms: return
+        if id(cls) in cls._setup_terms: return
 
         if cls == Ch:
             return
@@ -147,7 +147,7 @@ class Ch(object):
                 cls.term_order = list(cls.terms) + list(cls.dterms)
 
         _check_kw_conflict(cls)
-        cls._setup_terms[cls.__name__] = True
+        cls._setup_terms[id(cls)] = True
 
 
     ########################################################


### PR DESCRIPTION
For legacy code (e.g. in Korper) many are still using duplicate naming Ch object with opendr, which results in terms not set up for those legacy objects. It's safer to using unique identifiers. 
