### PR TITLE
Fixed reduce when drs contains LinearOperator

### DIFF
--- a/ch.py
+++ b/ch.py
@@ -709,6 +709,13 @@ class Ch(object):
                 if indirect_dr is not None:
                     drs.append(indirect_dr)
 
+        def _matvec(x):
+            '''
+            Aggregate drs starting from empty sparse matrix.
+
+            '''
+            return reduce(lambda acc, dr: acc+dr.dot(x), drs, sp.csc_matrix((drs[0].shape[0], x.shape[1])))
+
         if len(drs)==0:
             result = None
 
@@ -719,7 +726,7 @@ class Ch(object):
             if not np.any([isinstance(a, LinearOperator) for a in drs]):
                 result = reduce(lambda x, y: x+y, drs)
             else:
-                result = LinearOperator(drs[0].shape, lambda x : reduce(lambda a, b: a.dot(x)+b.dot(x),drs))
+                result = LinearOperator(drs[0].shape, matvec=_matvec)
 
         # TODO: figure out how/whether to do this.
         # if result is not None and not sp.issparse(result):

--- a/optimization.py
+++ b/optimization.py
@@ -364,6 +364,10 @@ def _minimize_dogleg(obj, free_variables, on_step=None,
                             100. * J.nnz / (J.shape[0] * J.shape[1])))
 
                         d_gn = col(solve(A, g)) if g.size>1 else np.atleast_1d(g.ravel()[0]/A[0,0])
+
+                        if np.isnan(np.min(d_gn)):
+                            d_gn = g
+
                         pif('sparse solve...done in %.2fs' % (time.time() - tm))
                     else:
                         pif('dense solve...')


### PR DESCRIPTION
There's a bug in the reduce usage for the LinearOperator where it combines first two elements initially and cause a dimension mismatch bug. Should use a empty matrix initializer to start with.    