### PR TITLE
Fix __all__ in ch

### DIFF
--- a/ch.py
+++ b/ch.py
@@ -7,7 +7,7 @@ See LICENCE.txt for licensing and contact information.
 """
 
 
-__all__ = ['Ch', 'depends_on']
+__all__ = ['Ch', 'depends_on', 'MatVecMult', 'ChHandle', 'ChLambda']
 
 import sys
 import inspect


### PR DESCRIPTION
Getting chumpy working on windows, we discovered that on osx and linux the `from ch import *` was pulling in everything despite the `__all__` in ch, so `chumpy.MatVecMult` was valid; on windows the `__all__` was being honored, so we couldn't directly access `MatVecMult` (have to address it as `chumpy.ch.MatVecMult`). I haven't dug in deep enough to know if this is a platform thing or if there's some setting that's defaulting differently in the various installs, or if it's a bug in the interpreter, but regardless, this change seems like the sane and defensive thing to do.