### PR TITLE
Fix broken Chumpy installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 chumpy
 ======
 
-Chumpy is a Python-based framework designed to handle the auto-differentiation problem, 
-which is to evalute an expression and its derivatives with respect to its inputs, with 
-the use of the chain rule. Chumpy is intended to make construction and local
-minimization of objectives easier. Specifically, it provides:
+Chumpy is a Python-based framework designed to handle the **auto-differentiation** problem,
+which is to evaluate an expression and its derivatives with respect to its inputs, by use of the chain rule.
+
+Chumpy is intended to make construction and local
+minimization of objectives easier.
+
+Specifically, it provides:
 
 - Easy problem construction by using Numpy’s application interface
 - Easy access to derivatives via auto differentiation
-- Easy local optimization methods (12 of them: most of which use the derivatives) 
+- Easy local optimization methods (12 of them: most of which use the derivatives)
 
-Chumpy comes with its own demos, which can be seen by typing the following::
+Chumpy comes with its own demos, which can be seen by typing the following:
 
->> import chumpy
->> chumpy.demo() # prints out a list of possible demos
+```python
+import chumpy
+chumpy.demo() # prints out a list of possible demos
+```
 
 Licensing is specified in the attached LICENSE.txt.
-

--- a/chumpy/version.py
+++ b/chumpy/version.py
@@ -1,3 +1,3 @@
-version = '0.67.4'
+version = '0.67.5'
 short_version = version
 full_version = version

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,14 @@ See LICENCE.txt for licensing and contact information.
 """
 
 from distutils.core import setup
-import importlib
 from pip.req import parse_requirements
+from runpy import run_path
 
 install_reqs = parse_requirements('requirements.txt', session=False)
 install_requires = [str(ir.req) for ir in install_reqs]
 
 def get_version():
-    namespace = {}
-    execfile('chumpy/version.py', namespace)
+    namespace = run_path('chumpy/version.py')
     return namespace['version']
 
 setup(name='chumpy',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,13 @@ from pip.req import parse_requirements
 install_reqs = parse_requirements('requirements.txt', session=False)
 install_requires = [str(ir.req) for ir in install_reqs]
 
+def get_version():
+    namespace = {}
+    execfile('chumpy/version.py', namespace)
+    return namespace['version']
+
 setup(name='chumpy',
-    version=importlib.import_module('chumpy').__version__,
+    version=get_version(),
     packages = ['chumpy'],
     author='Matthew Loper',
     author_email='matt.loper@gmail.com',


### PR DESCRIPTION
As noted in #13 the installation is currently broken, as `setup.py` tries to import chumpy to get the version string, which fails when any of chumpy's own requirements aren't installed beforehand. 

This fixes the issue by using `execfile` to directly grab the version string from `version.py` instead of attempting to import the actual chumpy package. Some minor markdown updates to the README file are also included.