### PR TITLE
version.py: bump version for pypi again

### DIFF
--- a/chumpy/version.py
+++ b/chumpy/version.py
@@ -1,3 +1,3 @@
-version = '0.67.7'
+version = '0.69'
 short_version = version
 full_version = version


### PR DESCRIPTION
bump version for pypi again, since there was a mixup about which was the latest on pypi