### PR TITLE
Delete unused and deprecated import

### DIFF
--- a/chumpy/__init__.py
+++ b/chumpy/__init__.py
@@ -8,7 +8,6 @@ from .version import version as __version__
 
 from .version import version as __version__
 
-from numpy import bool, int, float, complex, object, unicode, str, nan, inf
 
 def test():
     from os.path import split


### PR DESCRIPTION
This makes Chumpy work with latest numpy version